### PR TITLE
Add custom transport optional function

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -112,6 +112,14 @@ func WithDefaultTransport(transportTimeout time.Duration) func(*HTTPClient) {
 	}
 }
 
+// WithTransport configures the client to use a custom *http.Transport
+// More information about transport: [net/http.Transport]
+func WithTransport(transport *http.Transport) func(*HTTPClient) {
+	return func(client *HTTPClient) {
+		client.setTransport(transport)
+	}
+}
+
 // WithOAUTHTransport allows the client to make OAuth HTTP requests with custom timeout.
 // This timeout limits the time spent establishing a TCP connection.
 //


### PR DESCRIPTION
After some internal discussion, we found that a function allowing to set a custom transport would be useful for situations you don't want to use the default one.

This PR adds an optional function that allows the developer to set a custom transport for the http client