### PR TITLE
Add tests coverage visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .vscode/
 .idea/
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 PACKAGES ?= "$(shell go list ./... | grep -v tests)"
 
 test:
-	@go test -race $(shell echo $(PACKAGES))
+	@go test ./... -coverprofile=coverage.out.tmp
+	cat coverage.out.tmp | grep -v "/mocks/" > coverage.out
+	@go tool cover -func=coverage.out
+
+local-coverage: test
+	@go tool cover -html=coverage.out -o coverage.html
+	@echo "\n\n open the coverage.html on your browser !!!"
 
 lint:
 	@golangci-lint run


### PR DESCRIPTION
## Changes

This PR improves the test workflow and coverage visibility for the project.

### Makefile
- **Enhanced test target:**
  - The `test` target now runs all tests with coverage enabled (`go test ./... -coverprofile=coverage.out.tmp`).
  - Filters out coverage results for `/mocks/` to produce a cleaner `coverage.out` file.
  - Displays a coverage summary using `go tool cover -func=coverage.out`.
- **New target: `local-coverage`:**
  - Runs the test target and generates an HTML coverage report (`coverage.html`).
  - Prints a message instructing the user to open the HTML file in their browser.

## Outputs

<details>
<summary>local coverage report</summary>
<img width="1235" height="1087" alt="Screenshot 2026-01-18 at 22 42 56" src="https://github.com/user-attachments/assets/71f537aa-7043-4a1c-b804-b4a3ffd5efc0" />
</details>

## How to Test
- Run `make test` to see the coverage summary in the terminal.
- Run `make local-coverage` to generate and view the HTML coverage report.