### PR TITLE
Add support to send additional attributes on counter metric

### DIFF
--- a/request.go
+++ b/request.go
@@ -13,12 +13,13 @@ import (
 )
 
 type Request struct {
-	alias         string
-	chainCallback Callback
-	hostURL       *url.URL
-	metrics       Metrics
-	restyRequest  *resty.Request
-	startTime     time.Time
+	alias           string
+	chainCallback   Callback
+	hostURL         *url.URL
+	metrics         Metrics
+	additionalAttrs map[string]string
+	restyRequest    *resty.Request
+	startTime       time.Time
 }
 
 // NewRequest creates a request for the specified HTTP method.
@@ -34,6 +35,11 @@ func (c *HTTPClient) NewRequest() *Request {
 // HostURL returns the setted host url.
 func (r *Request) HostURL() *url.URL {
 	return r.hostURL
+}
+
+func (r *Request) SetMetricsAttrs(attrs map[string]string) *Request {
+	r.additionalAttrs = attrs
+	return r
 }
 
 // SetHostURL sets the host url for the request.
@@ -131,6 +137,11 @@ func (r *Request) Execute(method string, url string) (*Response, error) {
 
 	metricsAlias = strings.Replace(metricsAlias, ".", "-", -1)
 
+	attrs := r.additionalAttrs
+	if len(r.additionalAttrs) == 0 {
+		attrs = map[string]string{}
+	}
+
 	return registerMetrics(metricsAlias, r.metrics, func() (*Response, error) {
 		execute := func() (*Response, error) {
 			r.startTime = time.Now()
@@ -142,24 +153,21 @@ func (r *Request) Execute(method string, url string) (*Response, error) {
 		}
 
 		return r.chainCallback(execute)
-	})
+	}, attrs)
 }
 
-func registerMetrics(key string, metrics Metrics, f func() (*Response, error)) (*Response, error) {
+func registerMetrics(key string, metrics Metrics, f func() (*Response, error), additionalAttrs map[string]string) (*Response, error) {
 	resp, err := f()
 
 	if metrics != nil {
 		go func(resp *Response, err error) {
-			var attrs map[string]string
 			if resp != nil {
-				attrs = map[string]string{
-					"host": resp.Request().HostURL().Host,
-					"path": resp.Request().HostURL().Path,
-				}
+				additionalAttrs["host"] = resp.Request().HostURL().Host
+				additionalAttrs["path"] = resp.Request().HostURL().Path
 				metrics.PushToSeries(fmt.Sprintf("%s.%s", key, "response_time"), resp.ResponseTime().Seconds())
 				if resp.statusCode != 0 {
 					metrics.IncrCounter(fmt.Sprintf("%s.status.%d", key, resp.StatusCode()))
-					attrs["status"] = fmt.Sprintf("%d", resp.StatusCode())
+					additionalAttrs["status"] = fmt.Sprintf("%d", resp.StatusCode())
 				}
 			}
 			if err != nil {
@@ -169,7 +177,7 @@ func registerMetrics(key string, metrics Metrics, f func() (*Response, error)) (
 					metrics.IncrCounter(fmt.Sprintf("%s.%s", key, "errors"))
 				}
 			}
-			metrics.IncrCounterWithAttrs(fmt.Sprintf("%s.%s", key, "total"), attrs)
+			metrics.IncrCounterWithAttrs(fmt.Sprintf("%s.%s", key, "total"), additionalAttrs)
 		}(resp, err)
 	}
 

--- a/request.go
+++ b/request.go
@@ -171,7 +171,7 @@ func registerMetrics(key string, metrics Metrics, f func() (*Response, error), a
 					metrics.IncrCounter(fmt.Sprintf("%s.%s", key, "circuit_open"))
 				} else {
 					metrics.IncrCounter(fmt.Sprintf("%s.%s", key, "errors"))
-					attrs["error"] = err.Error()
+					additionalAttrs["error"] = err.Error()
 				}
 			}
 			metrics.IncrCounterWithAttrs(fmt.Sprintf("%s.%s", key, "total"), additionalAttrs)

--- a/request.go
+++ b/request.go
@@ -25,10 +25,11 @@ type Request struct {
 // NewRequest creates a request for the specified HTTP method.
 func (c *HTTPClient) NewRequest() *Request {
 	return &Request{
-		restyRequest:  c.resty.NewRequest(),
-		chainCallback: c.callbackChain,
-		metrics:       c.metrics,
-		hostURL:       c.hostURL,
+		restyRequest:    c.resty.NewRequest(),
+		chainCallback:   c.callbackChain,
+		metrics:         c.metrics,
+		hostURL:         c.hostURL,
+		additionalAttrs: map[string]string{},
 	}
 }
 
@@ -137,11 +138,6 @@ func (r *Request) Execute(method string, url string) (*Response, error) {
 
 	metricsAlias = strings.Replace(metricsAlias, ".", "-", -1)
 
-	attrs := r.additionalAttrs
-	if len(r.additionalAttrs) == 0 {
-		attrs = map[string]string{}
-	}
-
 	return registerMetrics(metricsAlias, r.metrics, func() (*Response, error) {
 		execute := func() (*Response, error) {
 			r.startTime = time.Now()
@@ -153,7 +149,7 @@ func (r *Request) Execute(method string, url string) (*Response, error) {
 		}
 
 		return r.chainCallback(execute)
-	}, attrs)
+	}, r.additionalAttrs)
 }
 
 func registerMetrics(key string, metrics Metrics, f func() (*Response, error), additionalAttrs map[string]string) (*Response, error) {

--- a/request_test.go
+++ b/request_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/globocom/httpclient"
 
@@ -159,4 +160,32 @@ func testSetHostURL(target *httpclient.Request) func(*testing.T) {
 		assert.Equal(t, target, result2)
 		assert.Nil(t, target.HostURL())
 	}
+}
+
+func TestSetMetricsAttrs_PropagatesToMetrics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(handleFunc))
+	defer server.Close()
+
+	metrics := &mockMetrics{}
+	client := httpclient.NewHTTPClient(
+		&httpclient.LoggerAdapter{Writer: io.Discard},
+		httpclient.WithHostURL(server.URL),
+		httpclient.WithMetrics(metrics),
+	)
+	request := client.NewRequest()
+
+	attrs := map[string]string{"foo": "bar", "baz": "qux"}
+	request.SetMetricsAttrs(attrs)
+	_, _ = request.Get("/")
+
+	time.Sleep(100 * time.Millisecond)
+
+	found := false
+	for _, calledAttrs := range metrics.incrCounterWithAttrsCalls {
+		if calledAttrs.attrs["foo"] == "bar" && calledAttrs.attrs["baz"] == "qux" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Attributes passed to SetMetricsAttrs must be propagated to IncrCounterWithAttrs")
 }


### PR DESCRIPTION
## Changes

### 1. Request Struct Enhancements
- Added a new field: `additionalAttrs map[string]string` to the `Request` struct.
- Added the method `SetMetricsAttrs(attrs map[string]string) *Request` to allow setting custom metric attributes for a request.

### 2. Metrics Propagation Logic
- In the `Execute` method of `Request`, the attributes set via `SetMetricsAttrs` are now propagated to the metrics logic.
- The `registerMetrics` function signature was updated to accept `additionalAttrs` as a parameter.
- The attributes are now correctly passed to `IncrCounterWithAttrs`, ensuring custom attributes are included in metrics.

## Motivation
- These changes improve the flexibility of metrics collection by allowing custom attributes to be attached to each request and ensuring they are included in all relevant metrics operations.

## How to Test
- Run the test suite (`go test ./...`).
- Ensure that `TestSetMetricsAttrs_PropagatesToMetrics` passes and that metrics attributes are correctly propagated.